### PR TITLE
Pin the versions of Lean and mathlib so that CI succeeds again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Get Lean version
         run: |
           set -o pipefail
-          source elan_setup.sh
+          # source elan_setup.sh
+          export LATEST_BROWSER_LEAN=3.46  # TODO: revert once we solve the 100Mb limit issue
           echo "LATEST_BROWSER_LEAN=$LATEST_BROWSER_LEAN" >> $GITHUB_ENV
 
       - name: install Python
@@ -62,7 +63,7 @@ jobs:
           cd combined_lib/
           git init
           elan override set leanprover-community/lean:$LATEST_BROWSER_LEAN
-          leanproject --no-lean-upgrade up
+          # leanproject --no-lean-upgrade up  # TODO: restore
           rm -rf _target/deps/mathlib/test
           rm -rf _target/deps/mathlib/scripts
           rm -rf _target/deps/mathlib/roadmap

--- a/combined_lib/leanpkg.toml
+++ b/combined_lib/leanpkg.toml
@@ -1,7 +1,7 @@
 [package]
 name = "combined_lib"
-version = "3.15.0"
-lean_version = "leanprover-community/lean:3.15.0"
+version = "3.46.0"
+lean_version = "leanprover-community/lean:3.46.0"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "79e296bdc9f83b9447dc1b81730d36f63a99f72d"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "1e6b748c175e64dd033d7a1a1bfe3e9fe72011d3"}


### PR DESCRIPTION
I was going to have a go at cleaning up the CI here; but it's hard to do so if I don't have a working baseline to start with.

By pinning to the mathlib version that is currently deployed, it should be possible to iterate on the CI script. We will eventually want to revert these changes.